### PR TITLE
Loosen LLM relevance threshold for news filtering

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -27,7 +27,7 @@ def extract_json_array(raw_text):
     return json.loads(text[start : end + 1])
 
 
-def classify_batch(items, client, filter_topics):
+def build_classification_prompt(items, filter_topics):
     payload = []
     for idx, it in enumerate(items, 1):
         payload.append(
@@ -41,11 +41,19 @@ def classify_batch(items, client, filter_topics):
     topics_text = "、".join([f"{t['topic']}（{t['description']}）" for t in filter_topics])
     instructions = (
         f"请判断以下每条新闻是否与这些主题相关：{topics_text}。\n"
+        "判断标准要放宽到中度相关也收，不要求新闻主题必须完全聚焦这些领域。\n"
+        "只要新闻与任一主题存在明确的业务、产品、融资、并购、平台策略或产业影响上的关联，就判定为 YES。\n"
+        "例如 AI 产品发布、AI 基础设施/模型/代理、社交平台功能与分发、直播平台与创作者生态、TMT 领域投融资/并购/资产出售/战略合作、手机游戏发行与增长动态，都应优先判定为 YES。\n"
+        "只有在新闻与这些主题几乎没有明确关联时，才判定为 NO。\n"
         "请严格按顺序返回一个 JSON 数组，数组长度必须等于输入条目数。\n"
         "数组元素只能是字符串 'YES' 或 'NO'，不要输出任何解释、代码块或多余文字。"
     )
 
-    prompt = f"{instructions}\n\n输入(JSON):\n{json.dumps(payload, ensure_ascii=False)}"
+    return f"{instructions}\n\n输入(JSON):\n{json.dumps(payload, ensure_ascii=False)}"
+
+
+def classify_batch(items, client, filter_topics):
+    prompt = build_classification_prompt(items, filter_topics)
 
     last_error = None
     for retry in range(MAX_RETRIES):

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -5,7 +5,7 @@ import pytest
 from src import config
 from src.filters import is_entry_within_lookback, normalize_news_url
 from src.history import dedupe_key_for_entry
-from src.llm import extract_json_array
+from src.llm import build_classification_prompt, extract_json_array
 
 
 def test_normalize_news_url_strips_tracking_and_lowercases():
@@ -60,6 +60,29 @@ def test_extract_json_array_fenced_json():
 def test_extract_json_array_empty_raises():
     with pytest.raises(ValueError):
         extract_json_array("")
+
+
+def test_build_classification_prompt_accepts_moderate_relevance():
+    topics = [
+        {"topic": "AI", "description": "人工智能"},
+        {"topic": "TMT acquisitions", "description": "TMT并购"},
+    ]
+
+    prompt = build_classification_prompt(
+        [
+            {
+                "title": "Big Tech signs new AI infrastructure partnership",
+                "summary": "The companies will jointly expand model hosting capacity and enterprise distribution.",
+            }
+        ],
+        topics,
+    )
+
+    assert "中度相关也收" in prompt
+    assert "业务、产品、融资、并购、平台策略或产业影响上的关联" in prompt
+    assert "不要求新闻主题必须完全聚焦这些领域" in prompt
+    assert "AI 基础设施/模型/代理" in prompt
+    assert "TMT 领域投融资/并购/资产出售/战略合作" in prompt
 
 
 def test_dedupe_key_prefers_normalized_url():


### PR DESCRIPTION
## Overview
This PR loosens the LLM relevance threshold for the daily news filter while keeping the current 3-day cross-run dedupe behavior unchanged.

## What Changed
- update the classification prompt so moderately related items are kept
- explicitly treat clear links through product, business, funding, M&A, platform strategy, or industry impact as `YES`
- keep the existing AI topic enabled
- add a test that locks in the new prompt behavior

## Why
Recent production runs became too strict after dedupe and only surfaced a very small number of items. This change keeps the dedupe guardrails but broadens the relevance threshold so medium-strength topical matches are still included.

## Validation
- `python3 -m pytest -q`
- `python3 -m ruff check .`
- `python3 -m black --check .`
- manual workflow run on `codex/loosen-filter-threshold`: [22949171310](https://github.com/Chenke0023/-/actions/runs/22949171310)
  - baseline on `main`: 2 relevant items ([issue #82](https://github.com/Chenke0023/-/issues/82))
  - loosened prompt branch: 16 relevant items ([issue #83](https://github.com/Chenke0023/-/issues/83))
  - overlap with issue #82 news links: 0
